### PR TITLE
replace python.ext.cors with python_cors

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from json import dumps
 import json
 from flask import Flask, Response, url_for, redirect
 from flask import request
-from flask.ext.cors import CORS, cross_origin
+from flask_cors import CORS, cross_origin
 import logging
 import getopt
 


### PR DESCRIPTION
Docker gives the following error /usr/local/lib/python2.7/dist-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.cors is deprecated, use flask_cors instead.